### PR TITLE
Use object references rather object copies

### DIFF
--- a/NanoESP.cpp
+++ b/NanoESP.cpp
@@ -52,7 +52,7 @@ boolean NanoESP::reset() {
   return success;
 }
 
-boolean NanoESP::sendCom(String command, char respond[])
+boolean NanoESP::sendCom(const String& command, char respond[])
 {	
   this->println(command);
   //if (debug){Serial.println(command);}
@@ -68,7 +68,7 @@ boolean NanoESP::sendCom(String command, char respond[])
   }
 }
 
-String NanoESP::sendCom(String command)
+String NanoESP::sendCom(const String& command)
 {
   this->println(command);
   return this->readString();
@@ -76,7 +76,7 @@ String NanoESP::sendCom(String command)
 
 //----------------------------------WiFi-Functions-----------------------------------------
 
-boolean NanoESP::configWifi(int modus, String ssid, String password) 
+boolean NanoESP::configWifi(int modus, const String& ssid, const String& password) 
 {
   boolean success = true;
   switch (modus)
@@ -107,7 +107,7 @@ boolean NanoESP::configWifiMode(int modus)
 }
 
 
-boolean NanoESP::configWifiStation(String ssid, String password)
+boolean NanoESP::configWifiStation(const String& ssid, const String& password)
 {
   boolean success = true;
   this->setTimeout(30000);
@@ -116,7 +116,7 @@ boolean NanoESP::configWifiStation(String ssid, String password)
   return success;
 }
 
-boolean NanoESP::configWifiAP( String ssid, String password)
+boolean NanoESP::configWifiAP( const String& ssid, const String& password)
 {
   boolean success = true;
   this->setTimeout(20000);
@@ -127,7 +127,7 @@ boolean NanoESP::configWifiAP( String ssid, String password)
 }
 
 
-boolean NanoESP::configWifiAP( String ssid, String password, int channel, int crypt)
+boolean NanoESP::configWifiAP( const String& ssid, const String& password, int channel, int crypt)
 {
   boolean success = true;
   this->setTimeout(20000);
@@ -151,7 +151,7 @@ String NanoESP::getIp()
 
 //----------------------------------Connection-Functions-----------------------------------------
 
-boolean NanoESP::newConnection(int id, String type, String ip ,unsigned int port) {  //single direction
+boolean NanoESP::newConnection(int id, const String& type, const String& ip ,unsigned int port) {  //single direction
   boolean success = true;
   this->setTimeout(10000);
   success &= sendCom(at+cip+"START=" + String(id) + ",\"" + String(type) + "\",\"" + String(ip) + "\"," + String(port), ok); 
@@ -165,7 +165,7 @@ boolean NanoESP::closeConnection(int id) {
   return success;
 }
 
-boolean NanoESP::startUdpServer(int id, String ip ,unsigned int port,unsigned int  recvport, int mode) { //dual direction
+boolean NanoESP::startUdpServer(int id, const String& ip ,unsigned int port, unsigned int  recvport, int mode) { //dual direction
   boolean success = true;
   success &= sendCom(at+cip+"START=" + String(id) + ",\"UDP\",\"" + String(ip) + "\"," + String(port) + "," + String(recvport) + "," + String(mode), ok);
   return success;
@@ -188,7 +188,7 @@ boolean NanoESP::endTcpServer() {
   return success;
 }
 
-boolean NanoESP::sendData(int id, String msg) {
+boolean NanoESP::sendData(int id, const String& msg) {
   boolean success = true;
 
   success &= sendCom(at+cip+"SEND=" + String(id) + "," + String(msg.length() + 2), ">");
@@ -209,7 +209,7 @@ bool NanoESP::sendRaw(int id, unsigned char data[], int LenChar) {
   }
 }
 
-boolean NanoESP::sendDataClose(int id, String msg) {
+boolean NanoESP::sendDataClose(int id, const String& msg) {
   boolean success = true;
 
   success &= sendCom(at+cip+"SEND=" + String(id) + "," + String(msg.length() + 2), ">");
@@ -233,7 +233,7 @@ int NanoESP::getId() {
   else return -1;
 }
 
- int NanoESP::ping(String address) {
+ int NanoESP::ping( const String& address) {
 // boolean success = true;
   this->println(at+"PING=\"" + String(address)+"\"");
 	this->find("+");

--- a/NanoESP.h
+++ b/NanoESP.h
@@ -26,28 +26,28 @@ class NanoESP : public SoftwareSerial {
   public:
     NanoESP() ; 
     boolean init(boolean vDebug=false);
-    boolean sendCom(String command, char respond[]);
-    String sendCom(String command);
+    boolean sendCom(const String& command, char respond[]);
+    String sendCom(const String& command);
     boolean setMultipleConnections();
     boolean setTransferMode() ;
     boolean reset();
 
-    boolean configWifi(int modus, String ssid, String password);
+    boolean configWifi(int modus, const String& ssid, const String& password);
     boolean configWifiMode(int modus);
-    boolean configWifiStation(String ssid, String password);
-    boolean configWifiAP(String ssid, String password);
-    boolean configWifiAP(String ssid, String password, int channel, int crypt);
+    boolean configWifiStation(const String& ssid, const String& password);
+    boolean configWifiAP(const String& ssid, const String& password);
+    boolean configWifiAP(const String& ssid, const String& password, int channel, int crypt);
     boolean disconnectWifi();
     String getIp();
 
-    boolean newConnection(int id, String type, String ip , unsigned int port);
+    boolean newConnection(int id, const String& type, const String& ip , unsigned int port);
     boolean closeConnection(int id) ;
-    boolean startUdpServer(int id, String ip , unsigned int port, unsigned int recvport, int mode=0);
+    boolean startUdpServer(int id, const String& ip , unsigned int port, unsigned int recvport, int mode=0);
     boolean endUdpServer(int id);
     boolean startTcpServer(unsigned int port) ;
     boolean endTcpServer();
-    boolean sendData(int id, String msg);
-    boolean sendDataClose(int id, String msg);
+    boolean sendData(int id, const String& msg);
+    boolean sendDataClose(int id, const String& msg);
     int getId(); 		//Obsolet? !!!
     //int ping(String adress); 
 
@@ -62,7 +62,7 @@ class NanoESP : public SoftwareSerial {
 	bool sendRaw(int id, unsigned char data[], int LenChar);
 	
 	//----NEW----28.04.2016
-	 int ping(String adress); 
+	 int ping(const String& adress); 
 	//bool sendNTPpacket(int id, String address);
 	//long getNTPpacket(int id, String address, int timeZone);
 	//----TEST------

--- a/NanoESP_Flash.h
+++ b/NanoESP_Flash.h
@@ -1,3 +1,8 @@
+#ifndef NanoESP_FLASH_H
+#define NanoESP_FLASH_H
+
 const char serverStreamResponse[] PROGMEM = {
   "HTTP/1.1 200 OK \nContent-Type: text/event-stream\nAccess-Control-Allow-Origin: *\nCache-Control: no-cache\r\n\r\n"
 };
+
+#endif

--- a/NanoESP_HTTP.cpp
+++ b/NanoESP_HTTP.cpp
@@ -91,7 +91,7 @@ bool NanoESP_HTTP::sendStreamHeader(int connectionId) {
   this->sendFromFlash(connectionId, serverStreamResponse, sizeof(serverStreamResponse) - 1);
 }
 
-bool NanoESP_HTTP::sendRequest(int id, char method[5], String address, String parameter) {
+bool NanoESP_HTTP::sendRequest(int id, char method[5], const String& address, const String& parameter) {
   String host = address.substring(0, address.indexOf('/'));
   String ressource = address.substring(address.indexOf('/'));
 
@@ -115,7 +115,7 @@ bool NanoESP_HTTP::sendRequest(int id, char method[5], String address, String pa
   return false;
 }
 
-bool NanoESP_HTTP::sendRequest(int id, char method[5], String address) {
+bool NanoESP_HTTP::sendRequest(int id, char method[5], const String& address) {
   return sendRequest( id,  method,  address, "");
 }
 

--- a/NanoESP_HTTP.h
+++ b/NanoESP_HTTP.h
@@ -19,8 +19,8 @@ class NanoESP_HTTP {
 	bool sendFromFlash(int client, const char *website, int len);
 	bool recvRequest(int &id, String &method, String &ressource, String &parameter);   //Müsste recvHTTP heißen //OBSOLET?!?
 	bool sendStreamHeader(int connectionId);		
-	bool sendRequest(int id, char method[5], String address, String parameter);
-	bool sendRequest(int id, char method[5], String address); 		
+	bool sendRequest(int id, char method[5], const String& address, const String& parameter);
+	bool sendRequest(int id, char method[5], const String& address);
 	
 	//New
 	bool recvHTTP(int id, int len, String &method, String &ressource, String &parameter);

--- a/NanoESP_MQTT.cpp
+++ b/NanoESP_MQTT.cpp
@@ -33,26 +33,26 @@ NanoESP_MQTT::NanoESP_MQTT(NanoESP& nanoesp):m_nanoesp(&nanoesp){
 }
 
 
-bool NanoESP_MQTT::connect(int id, String broker, unsigned int port, String deviceId, mqtt_msg * lastWill){
+bool NanoESP_MQTT::connect(int id, const String& broker, unsigned int port, const String& deviceId, mqtt_msg * lastWill){
 	return this->connect(id, broker, port, deviceId, cleanSession, keepAliveTime, lastWill, "","");
 }
 
-bool NanoESP_MQTT::connect(int id, String broker, unsigned int port, String deviceId, String userName , String password){
+bool NanoESP_MQTT::connect(int id, const String& broker, unsigned int port, const String& deviceId, const String& userName , const String& password){
 	mqtt_msg theLastWillDefault = {"", "", 0, 0};	
 	return this->connect(id, broker, port, deviceId, cleanSession, keepAliveTime, &theLastWillDefault, userName,password);
 }
 
-bool NanoESP_MQTT::connect(int id, String broker, unsigned int port, String deviceId, bool cleanSession, byte keepAliveTime){
+bool NanoESP_MQTT::connect(int id, const String& broker, unsigned int port, const String& deviceId, bool cleanSession, byte keepAliveTime){
 	mqtt_msg theLastWillDefault = {"", "", 0, 0};	
 	return this->connect(id, broker, port, deviceId, cleanSession, keepAliveTime, &theLastWillDefault, "","");
 	
 }
-bool NanoESP_MQTT::connect(int id, String broker, unsigned int port, String deviceId, mqtt_msg * lastWill , String userName , String password){
+bool NanoESP_MQTT::connect(int id, const String& broker, unsigned int port, const String& deviceId, mqtt_msg * lastWill, const String& userName, const String& password){
 	return this->connect(id, broker, port, deviceId, cleanSession, keepAliveTime, lastWill, userName,password);
 
 }
 
-bool NanoESP_MQTT::connect(int id, String broker, unsigned int port, String deviceId, bool cleanSession, byte vkeepAliveTime, mqtt_msg * lastWill , String userName , String password)
+bool NanoESP_MQTT::connect(int id, const String& broker, unsigned int port, const String& deviceId, bool cleanSession, byte vkeepAliveTime, mqtt_msg * lastWill, const String& userName, const String& password)
 {
   if (!m_nanoesp->newConnection(id, TCP, broker, port)) return false;
 
@@ -160,7 +160,7 @@ bool NanoESP_MQTT::connect(int id, String broker, unsigned int port, String devi
 }
 
 
-bool NanoESP_MQTT::connect(int id, String broker,unsigned  int port, String deviceId) {
+bool NanoESP_MQTT::connect(int id, const String& broker,unsigned  int port, const String& deviceId) {
   mqtt_msg theLastWillDefault = {"", "", 0, 0};	
   return this->connect(id, broker, port, deviceId, cleanSession, keepAliveTime, &theLastWillDefault, "","");
 }
@@ -177,12 +177,12 @@ bool NanoESP_MQTT::disconnect(int id) {
 }
 
 
-bool NanoESP_MQTT::publish(int id, String topic, String value, byte qos, bool retain){
+bool NanoESP_MQTT::publish(int id, const String& topic, const String& value, byte qos, bool retain){
 	mqtt_msg msg = {topic, value, qos, retain};	
 	return this->publish(id, &msg);
 }
 
-bool NanoESP_MQTT::publish(int id, String topic, String value) {
+bool NanoESP_MQTT::publish(int id, const String& topic, const String& value) {
 	mqtt_msg msg = {topic, value, 0, 0};	
 	return this->publish(id, &msg);
 }
@@ -271,7 +271,7 @@ bool NanoESP_MQTT::recvMQTT(int &id, String &topic, String &value) {
 }
 
 
-bool NanoESP_MQTT::subscribe(int id, String topic, byte qos, void (*g)(String value)) 
+bool NanoESP_MQTT::subscribe(int id, const String& topic, byte qos, void (*g)(const String& value)) 
 {
 		if (this->subscribe(id,topic,qos)){
 			for (int i = 0; i<maxEvents; i++){
@@ -286,7 +286,7 @@ bool NanoESP_MQTT::subscribe(int id, String topic, byte qos, void (*g)(String va
   return false;
 }
 
-bool NanoESP_MQTT::subscribe(int id, String topic, byte qos) {
+bool NanoESP_MQTT::subscribe(int id, const String& topic, byte qos) {
 
   // Fixed Head,MS,LSB,    ,M,   Q       ?       ?   ?     ?  ,Ver X?,Conec,Kepp Alive tim
   unsigned char data[]  = {
@@ -316,7 +316,7 @@ bool NanoESP_MQTT::subscribe(int id, String topic, byte qos) {
 }
 
 
-bool NanoESP_MQTT::subscribe(int id, String topic) {
+bool NanoESP_MQTT::subscribe(int id, const String& topic) {
 
   // Fixed Head,MS,LSB,    ,M,   Q       ?       ?   ?     ?  ,Ver X?,Conec,Kepp Alive tim
   unsigned char data[]  = {
@@ -346,7 +346,7 @@ bool NanoESP_MQTT::subscribe(int id, String topic) {
   if (send(id, msg, sizeof(msg))) return true; else return false;
 }
 
-bool NanoESP_MQTT::unsubscribe(int id, String topic) {
+bool NanoESP_MQTT::unsubscribe(int id, const String& topic) {
 
   // Fixed Head,MS,LSB,    ,M,   Q       ?       ?   ?     ?  ,Ver X?,Conec,Kepp Alive tim
   unsigned char data[]  = {
@@ -472,7 +472,7 @@ return false;
 }
 
 
-bool NanoESP_MQTT::topicCompare(String topic1, String topic2) {
+bool NanoESP_MQTT::topicCompare( const String& topic1, const String& topic2) {
 //Serial.println(topic1 +" - "+topic2);
 	
   if (topic1 == "") return false;
@@ -525,7 +525,7 @@ void NanoESP_MQTT::stayConnected(int id){
 	this->stayConnected(id, interval);
 }
 
-void NanoESP_MQTT::utf8(String input, unsigned char* output) {
+void NanoESP_MQTT::utf8(const String& input, unsigned char* output) {
   byte len = input.length();
 
   output[0] = 0;

--- a/NanoESP_MQTT.h
+++ b/NanoESP_MQTT.h
@@ -19,7 +19,7 @@
  
  typedef struct {
   String topic;
-  void (*g)(String value);
+  void (*g)(const String&  value);
 } mqtt_event;
 
 class NanoESP_MQTT { 
@@ -32,8 +32,8 @@ class NanoESP_MQTT {
     bool disconnect(int id) ;
    
     bool recvMQTT(int &id, String &topic, String &value) ;  //Obsolet!
-    bool subscribe(int id, String topic) ;
-    bool unsubscribe(int id, String topic) ;
+    bool subscribe(int id, const String& topic) ;
+    bool unsubscribe(int id, const String& topic) ;
     bool ping(int id);
     bool send(int id, unsigned char data[], int LenChar);
     bool send(int id, unsigned char data[], int LenChar, char ack);
@@ -43,29 +43,27 @@ class NanoESP_MQTT {
 	void stayConnected(int id, long interval);
     void stayConnected(int id);
 		
-	void utf8(String input,unsigned char* output);
+	void utf8(const String& input, unsigned char* output);
     void charAdd(unsigned char* inputA, int lenA,unsigned char* inputB, int lenB, unsigned char* output);
 	
-	bool connect(int id, String broker, unsigned int port, String deviceId, bool cleanSession, byte keepAliveTime, mqtt_msg * lastWill , String userName , String password);
-	bool connect(int id, String broker, unsigned int port, String deviceId);
-	bool connect(int id, String broker, unsigned int port, String deviceId, mqtt_msg * lastWill);
-	bool connect(int id, String broker, unsigned int port, String deviceId, bool cleanSession, byte keepAliveTime, mqtt_msg * lastWill);
-	bool connect(int id, String broker, unsigned int port, String deviceId, String userName , String password);
-	bool connect(int id, String broker, unsigned int port, String deviceId, bool cleanSession, byte keepAliveTime);
-	bool connect(int id, String broker, unsigned int port, String deviceId, mqtt_msg * lastWill , String userName , String password);
-	//static mqtt_msg theLastWillDefault = {"", "", 0, 0};	
-	//bool connect(int id, String broker, int port, String deviceId, bool cleanSession = true, byte keepAliveTime = 120, mqtt_msg *lastWill = &theLastWillDefault, String userName = "", String password = "");
-	
+	bool connect(int id, const String& broker, unsigned int port, const String& deviceId, bool cleanSession, byte keepAliveTime, mqtt_msg * lastWill , const String& userName , const String&  password);
+	bool connect(int id, const String& broker, unsigned int port, const String& deviceId);
+	bool connect(int id, const String& broker, unsigned int port, const String& deviceId, mqtt_msg * lastWill);
+	bool connect(int id, const String& broker, unsigned int port, const String& deviceId, bool cleanSession, byte keepAliveTime, mqtt_msg * lastWill);
+	bool connect(int id, const String& broker, unsigned int port, const String& deviceId, const String&  userName , const String&  password);
+	bool connect(int id, const String& broker, unsigned int port, const String& deviceId, bool cleanSession, byte keepAliveTime);
+	bool connect(int id, const String& broker, unsigned int port, const String& deviceId, mqtt_msg * lastWill, const String& userName, const String&  password);
+
 	
 	bool publish(int id, mqtt_msg *msg);
-	bool publish(int id, String topic, String value);
-	bool publish(int id, String topic, String value, byte qos, bool retain);
+	bool publish(int id, const String&  topic, const String&  value);
+	bool publish(int id, const String&  topic, const String&  value, byte qos, bool retain);
 	
-	bool subscribe(int id, String topic, byte qos);
-	bool subscribe(int id, String topic, byte qos, void (*g)(String value));
+	bool subscribe(int id, const String&  topic, byte qos);
+	bool subscribe(int id, const String&  topic, byte qos, void (*g)(const String&  value));
 	
 	bool recvMQTT(int id, int len);
-	bool topicCompare(String topic1, String topic2);
+	bool topicCompare(const String&  topic1, const String&  topic2);
 	byte keepAliveTime = 120;
 	
 	


### PR DESCRIPTION
Throughout the code you will find String objects when calling methods. Help the compiler generate faster and smaller code by using string references.

For a discussion see Scott Meyer Effective C++ or for more recent discussion  http://stackoverflow.com/questions/270408/is-it-better-in-c-to-pass-by-value-or-pass-by-constant-reference

With a tiny project of mine the code size has been dropped from 17150 Bytes to 16784 by this change alone.