### PR TITLE
NanoESP MQTT Fix

### DIFF
--- a/NanoESP_MQTT.cpp
+++ b/NanoESP_MQTT.cpp
@@ -172,6 +172,11 @@ bool NanoESP_MQTT::disconnect(int id) {
     //Header
     MQTT_DISCON, 0x00, //Publish
   };
+  
+  // Clear subscribe.
+  for (int i = 0; i<maxEvents; i++){
+	events[i].topic = "";
+  }
 
   if (send(id, data, sizeof(data))) return true; else return false;
 }

--- a/NanoESP_MQTT.cpp
+++ b/NanoESP_MQTT.cpp
@@ -426,17 +426,18 @@ bool NanoESP_MQTT::send(int id, unsigned char data[], int LenChar, char ack) {
 }
 
 //NEW
-bool NanoESP_MQTT::recvMQTT(int id, int len, String &topic, String &value) {
+bool NanoESP_MQTT::recvMQTT(int /*id*/, int len, String &topic, String &value) {
 	if (len>0){
 		if( m_nanoesp->findUntil(":", "\n")){               //+IPD, 0, 407: GET / HTTP / 1.1
 			char buffer[len];
-			m_nanoesp->readBytes(buffer, len);
+			// Use read bytes only, not complete buffer length, there might be bullshit in the buffer
+			len = m_nanoesp->readBytes(buffer, len);
 
 			if ((buffer[0] & 11110000) == MQTT_PUB) {
-				byte qos = buffer[0] & 00000110;
-				bool retain = bitRead(buffer[0],0);			
+				const byte qos = buffer[0] & 00000110;
+				//bool retain = bitRead(buffer[0],0);
 				
-				byte lenTopic = buffer[3];
+				const byte lenTopic = buffer[3];
 
 				for (int i = 0; i < lenTopic; i++) {
 					topic += buffer[i + 4];


### PR DESCRIPTION
Dear Mr. Kainka,

I made two fixes:

1. Cut the message in recvMQTT at the last valid byte. This avoids invalid data at the end of the message
2. Clear events array during disconnect. Otherwise overflow in the events array after some reconnects.

I know that the NanoESP is a bit outdated, but I found an old one in my box and used it in a project. 10 years ago they were really cool!

Best regards
Mathias Moog