### PR TITLE
fix/phase1: Bugfixes, Lizenz, CI

### DIFF
--- a/.github/workflows/arduino-compile.yml
+++ b/.github/workflows/arduino-compile.yml
@@ -39,6 +39,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # NOTE: real `pio test -e native` is wired up in Phase 2 (feat/pio-native-tests).
-      - name: Placeholder
-        run: echo "native unit tests are added in Phase 2"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+
+      - name: Run native unit tests
+        run: pio test -e native

--- a/.github/workflows/arduino-compile.yml
+++ b/.github/workflows/arduino-compile.yml
@@ -37,11 +37,13 @@ jobs:
             echo "::endgroup::"
           done
 
-  native-tests:
-    name: Native unit tests (PlatformIO)
+  native-tests-placeholder:
+    name: Native unit tests (placeholder)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # NOTE: real `pio test -e native` is wired up in Phase 2 (feat/pio-native-tests).
-      - name: Placeholder
-        run: echo "native unit tests are added in Phase 2"
+      # Real `pio test -e native` (with platformio.ini and the test/ tree) is
+      # introduced in the follow-up Phase 2 PR; this is only a placeholder so the
+      # job name is reserved and CI stays green here.
+      - name: Placeholder (no tests yet)
+        run: echo "PlatformIO native unit tests are added in the Phase 2 test PR"

--- a/.github/workflows/arduino-compile.yml
+++ b/.github/workflows/arduino-compile.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Compile all examples
         run: |
           set -e
-          find examples -name '*.ino' -print0 | while IFS= read -r -d '' sketch; do
+          # The Blynk example pulls in third-party libraries (ESP8266_SoftSer.h,
+          # Blynk) that are not part of this repository, so it is skipped here.
+          find examples -name '*.ino' -not -path '*/Blynk/*' -print0 \
+            | while IFS= read -r -d '' sketch; do
             echo "::group::Compiling $sketch"
             arduino-cli compile --fqbn arduino:avr:nano "$sketch"
             echo "::endgroup::"

--- a/.github/workflows/arduino-compile.yml
+++ b/.github/workflows/arduino-compile.yml
@@ -1,0 +1,44 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  compile-examples:
+    name: Compile examples (arduino-cli)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Arduino CLI
+        uses: arduino/setup-arduino-cli@v1
+
+      - name: Install AVR core
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install arduino:avr
+
+      - name: Make library available to the sketches
+        run: |
+          mkdir -p "$HOME/Arduino/libraries"
+          ln -s "$GITHUB_WORKSPACE" "$HOME/Arduino/libraries/NanoESP"
+
+      - name: Compile all examples
+        run: |
+          set -e
+          find examples -name '*.ino' -print0 | while IFS= read -r -d '' sketch; do
+            echo "::group::Compiling $sketch"
+            arduino-cli compile --fqbn arduino:avr:nano "$sketch"
+            echo "::endgroup::"
+          done
+
+  native-tests:
+    name: Native unit tests (PlatformIO)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # NOTE: real `pio test -e native` is wired up in Phase 2 (feat/pio-native-tests).
+      - name: Placeholder
+        run: echo "native unit tests are added in Phase 2"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.pio/
+.pioenvs/
+.piolibdeps/
+.vscode/

--- a/AGENT_WORKFLOW.md
+++ b/AGENT_WORKFLOW.md
@@ -1,0 +1,30 @@
+# Agent Workflow
+
+Rules for automated/agent contributions to this repository.
+
+## Branches
+- Never commit directly to `master`.
+- Use prefixed branches: `feature/<name>`, `fix/<name>`, `test/<name>`, `chore/<name>`.
+
+## Commits
+- [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `test:`, `chore:`, `refactor:`, `docs:`.
+- Author commits as:
+  ```
+  git -c user.name="Claude" -c user.email="noreply@anthropic.com" commit -m "..."
+  ```
+
+## Pull Requests
+- One reviewable unit per PR; open against `master`.
+- The PR body must contain `Closes #<nr>` for every issue it addresses.
+- Add Copilot as a reviewer.
+- All CI checks must be green before merge, and no open review comment may remain unresolved.
+
+## Architecture invariants
+- `NanoESP_HTTP` and `NanoESP_MQTT` aggregate `NanoESP` by reference (no inheritance).
+- No global state in `.cpp` files — keep state in class members.
+- Target ATmega328 (2 KB RAM): be frugal with `String` objects and VLAs.
+- `test/` code must not include real Arduino headers; it must compile in the PlatformIO `native` environment.
+
+## Testing
+- Native unit tests run with `pio test -e native`.
+- Examples are compiled in CI with `arduino-cli` for `arduino:avr:nano`.

--- a/AGENT_WORKFLOW.md
+++ b/AGENT_WORKFLOW.md
@@ -27,5 +27,4 @@ Rules for automated/agent contributions to this repository.
 
 ## Testing
 - Examples are compiled in CI with `arduino-cli` for `arduino:avr:nano`.
-- Native unit tests run with `pio test -e native` once the PlatformIO config
-  (`platformio.ini` + `test/`) lands in the Phase 2 test PR.
+- Native unit tests run with `pio test -e native` (see `platformio.ini` and `test/`).

--- a/AGENT_WORKFLOW.md
+++ b/AGENT_WORKFLOW.md
@@ -21,7 +21,8 @@ Rules for automated/agent contributions to this repository.
 
 ## Architecture invariants
 - `NanoESP_HTTP` and `NanoESP_MQTT` aggregate `NanoESP` by reference (no inheritance).
-- No global state in `.cpp` files — keep state in class members.
+- Do not introduce new global state in `.cpp` files — keep state in class
+  members (some legacy file-scope globals still exist and should be migrated).
 - Target ATmega328 (2 KB RAM): be frugal with `String` objects and VLAs.
 - `test/` code must not include real Arduino headers; it must compile in the PlatformIO `native` environment.
 

--- a/AGENT_WORKFLOW.md
+++ b/AGENT_WORKFLOW.md
@@ -26,5 +26,6 @@ Rules for automated/agent contributions to this repository.
 - `test/` code must not include real Arduino headers; it must compile in the PlatformIO `native` environment.
 
 ## Testing
-- Native unit tests run with `pio test -e native`.
 - Examples are compiled in CI with `arduino-cli` for `arduino:avr:nano`.
+- Native unit tests run with `pio test -e native` once the PlatformIO config
+  (`platformio.ini` + `test/`) lands in the Phase 2 test PR.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015-2026 Fabian Kainka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NanoESP.cpp
+++ b/NanoESP.cpp
@@ -98,7 +98,11 @@ boolean NanoESP::configWifi(int modus, const String& ssid, const String& passwor
       success &= configWifiStation(ssid, password);
       return success;
       break;
+
+    default:
+      return false;
   }
+  return false;
 }
 
 boolean NanoESP::configWifiMode(int modus)

--- a/NanoESP.cpp
+++ b/NanoESP.cpp
@@ -102,7 +102,6 @@ boolean NanoESP::configWifi(int modus, const String& ssid, const String& passwor
     default:
       return false;
   }
-  return false;
 }
 
 boolean NanoESP::configWifiMode(int modus)

--- a/NanoESP.h
+++ b/NanoESP.h
@@ -4,8 +4,8 @@
   www.iot.fkainka.de
 */
 
-#ifndef NANOESP_H
-#define NANOESP_H
+#ifndef NanoESP_H
+#define NanoESP_H
 
 #define STATION 1
 #define ACCESSPOINT 2

--- a/NanoESP.h
+++ b/NanoESP.h
@@ -4,6 +4,8 @@
   www.iot.fkainka.de
 */
 
+#ifndef _NANOESP_H_
+#define _NANOESP_H_
 
 #define STATION 1
 #define ACCESSPOINT 2
@@ -13,11 +15,7 @@
 #define UDP "UDP"
 
 #define GET "GET"
-#define POST "PSOT"
-
-
-#ifndef _NANOESP_H_
-#define _NANOESP_H_
+#define POST "POST"
 
 #include "Arduino.h"
 #include <SoftwareSerial.h>

--- a/NanoESP.h
+++ b/NanoESP.h
@@ -4,8 +4,8 @@
   www.iot.fkainka.de
 */
 
-#ifndef _NANOESP_H_
-#define _NANOESP_H_
+#ifndef NANOESP_H
+#define NANOESP_H
 
 #define STATION 1
 #define ACCESSPOINT 2

--- a/NanoESP_HTTP.cpp
+++ b/NanoESP_HTTP.cpp
@@ -88,7 +88,7 @@ bool NanoESP_HTTP::recvHTTP(int id, int len, String &method, String &ressource, 
 
 
 bool NanoESP_HTTP::sendStreamHeader(int connectionId) {
-  this->sendFromFlash(connectionId, serverStreamResponse, sizeof(serverStreamResponse) - 1);
+  return this->sendFromFlash(connectionId, serverStreamResponse, sizeof(serverStreamResponse) - 1);
 }
 
 bool NanoESP_HTTP::sendRequest(int id, char method[5], const String& address, const String& parameter) {

--- a/NanoESP_MQTT.cpp
+++ b/NanoESP_MQTT.cpp
@@ -480,7 +480,7 @@ bool NanoESP_MQTT::topicCompare( const String& topic1, const String& topic2) {
 
   if (topic1.indexOf('+') > 0) {
     int pos1 = topic1.indexOf('/');
-    int pos2 = topic1.indexOf('/');
+    int pos2 = topic2.indexOf('/');
 
     String restTopic1 = topic1;
     String restTopic2 = topic2;

--- a/NanoESP_MQTT.cpp
+++ b/NanoESP_MQTT.cpp
@@ -22,11 +22,6 @@ const byte MQTT_PING = 12 << 4; //Ping
 const byte MQTT_PINGACK = 13 << 4;
 const byte MQTT_DISCON = 14 << 4; //Disconnect
 
-bool cleanSession = true;
-//this->keepAliveTime = 120; //If no Message is sent from Client to Server within this time the connection will be terminated
-unsigned long previousMillisMQTTsend = 0;        // will store last time a msg was send
-//this->interval = (keepAliveTime*1000)/2;           // interval a ping is send to stay connected
-
 
 NanoESP_MQTT::NanoESP_MQTT(NanoESP& nanoesp):m_nanoesp(&nanoesp){
 
@@ -259,7 +254,7 @@ bool NanoESP_MQTT::recvMQTT(int &id, String &topic, String &value) {
       m_nanoesp->find(":");
       m_nanoesp->readBytes(buffer, len);
 
-      if ((buffer[0] & 11110000) == MQTT_PUB) {
+      if ((buffer[0] & 0b11110000) == MQTT_PUB) {
         byte lenTopic = buffer[3];
 
         for (int i = 0; i < lenTopic; i++) {
@@ -438,8 +433,8 @@ bool NanoESP_MQTT::recvMQTT(int /*id*/, int len, String &topic, String &value) {
 			// Use read bytes only, not complete buffer length, there might be bullshit in the buffer
 			len = m_nanoesp->readBytes(buffer, len);
 
-			if ((buffer[0] & 11110000) == MQTT_PUB) {
-				const byte qos = buffer[0] & 00000110;
+			if ((buffer[0] & 0b11110000) == MQTT_PUB) {
+				const byte qos = buffer[0] & 0b00000110;
 				//bool retain = bitRead(buffer[0],0);
 				
 				const byte lenTopic = buffer[3];

--- a/NanoESP_MQTT.h
+++ b/NanoESP_MQTT.h
@@ -65,14 +65,14 @@ class NanoESP_MQTT {
 	bool recvMQTT(int id, int len);
 	bool topicCompare(const String&  topic1, const String&  topic2);
 	byte keepAliveTime = 120;
-	bool cleanSession = true;   //If no Message is sent from Client to Server within keepAliveTime the connection will be terminated
+	bool cleanSession = true;   //If true the broker discards any previous session state on connect; if false it keeps subscriptions/queued QoS messages
 
 
   private:
     static const byte maxEvents = 5;
 	mqtt_event events[maxEvents];
 
-	unsigned long previousMillisMQTTsend = 0;   // will store last time a msg was send
+	unsigned long previousMillisMQTTsend = 0;   // will store last time a msg was sent
 
     NanoESP* m_nanoesp;
 	

--- a/NanoESP_MQTT.h
+++ b/NanoESP_MQTT.h
@@ -65,12 +65,15 @@ class NanoESP_MQTT {
 	bool recvMQTT(int id, int len);
 	bool topicCompare(const String&  topic1, const String&  topic2);
 	byte keepAliveTime = 120;
-	
-	
+	bool cleanSession = true;   //If no Message is sent from Client to Server within keepAliveTime the connection will be terminated
+
+
   private:
     static const byte maxEvents = 5;
 	mqtt_event events[maxEvents];
-	
+
+	unsigned long previousMillisMQTTsend = 0;   // will store last time a msg was send
+
     NanoESP* m_nanoesp;
 	
 		

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=NanoESP
+version=1.1.0
+author=Fabian Kainka
+maintainer=Fabian Kainka <f.kainka@gmail.com>
+sentence=Arduino library for the NanoESP / Pretzelboard (Arduino Nano + ESP8266).
+paragraph=Abstracts the ESP8266 AT-command firmware into easy-to-use WiFi, TCP/UDP, HTTP REST/webserver and MQTT client functions for the NanoESP board.
+category=Communication
+url=https://github.com/FKainka/NanoESP
+architectures=avr
+includes=NanoESP.h

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,11 +10,16 @@ platform = atmelavr
 board = nanoatmega328
 framework = arduino
 monitor_speed = 19200
+; src_dir is the repo root (see [platformio]); restrict the board build to the
+; library sources so it does not pull in examples/ or test/. Building an actual
+; firmware requires supplying your own sketch with setup()/loop().
+build_src_filter = -<*> +<NanoESP.cpp> +<NanoESP_HTTP.cpp> +<NanoESP_MQTT.cpp>
 
 [env:native]
 platform = native
 build_flags =
-    -std=c++17
+    ; gnu++17 (not c++17): NanoESP_MQTT.cpp relies on GNU VLAs.
+    -std=gnu++17
     -I test/native/mocks
     -I .
 ; Compile only the MQTT translation unit against the stub headers; the other

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,23 @@
+; PlatformIO project configuration for the NanoESP library.
+; - env:nano    builds/uploads for the NanoESP board (Arduino Nano, ATmega328).
+; - env:native  runs the host-side Unity unit tests (`pio test -e native`).
+
+[platformio]
+src_dir = .
+
+[env:nano]
+platform = atmelavr
+board = nanoatmega328
+framework = arduino
+monitor_speed = 19200
+
+[env:native]
+platform = native
+build_flags =
+    -std=c++17
+    -I test/native/mocks
+    -I .
+; Compile only the MQTT translation unit against the stub headers; the other
+; library sources need real Arduino/SoftwareSerial and aren't under test here.
+build_src_filter = -<*> +<NanoESP_MQTT.cpp>
+test_build_src = true

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,6 +4,8 @@
 
 [platformio]
 src_dir = .
+; Plain `pio run`/`pio test` target the host tests; env:nano needs a user sketch.
+default_envs = native
 
 [env:nano]
 platform = atmelavr

--- a/test/native/mocks/Arduino.h
+++ b/test/native/mocks/Arduino.h
@@ -1,0 +1,98 @@
+// Minimal Arduino.h stub for the PlatformIO `native` test environment.
+// Provides just enough of the Arduino API (types, String, Serial, millis)
+// for the real NanoESP_MQTT.cpp translation unit to compile and link on a
+// desktop host. None of the hardware-touching stubs are ever executed by the
+// unit tests — they only need to satisfy the compiler and linker.
+#ifndef NANOESP_NATIVE_ARDUINO_H
+#define NANOESP_NATIVE_ARDUINO_H
+
+#include <cstdint>
+#include <string>
+
+typedef uint8_t byte;
+typedef bool boolean;
+
+#define HEX 16
+#define DEC 10
+#define BIN 2
+#define OCT 8
+
+#define F(string_literal) (string_literal)
+#define bitRead(value, bit) (((value) >> (bit)) & 0x01)
+
+inline unsigned long millis() { return 0UL; }
+
+// --- Arduino String shim, backed by std::string -----------------------------
+class String {
+  std::string s;
+ public:
+  String() {}
+  String(const char* c) : s(c ? c : "") {}
+  String(char c) : s(1, c) {}
+  String(int n) : s(std::to_string(n)) {}
+  String(unsigned int n) : s(std::to_string(n)) {}
+  String(long n) : s(std::to_string(n)) {}
+  String(unsigned long n) : s(std::to_string(n)) {}
+
+  unsigned int length() const { return (unsigned int)s.length(); }
+  const char* c_str() const { return s.c_str(); }
+
+  char operator[](int i) const { return s[(size_t)i]; }
+  char& operator[](int i) { return s[(size_t)i]; }
+
+  int indexOf(char c) const {
+    size_t p = s.find(c);
+    return p == std::string::npos ? -1 : (int)p;
+  }
+  int indexOf(const char* o) const {
+    size_t p = s.find(o);
+    return p == std::string::npos ? -1 : (int)p;
+  }
+  int indexOf(const String& o) const { return indexOf(o.c_str()); }
+
+  String substring(int from) const {
+    if (from < 0) from = 0;
+    if ((size_t)from >= s.size()) return String();
+    return String(s.substr((size_t)from).c_str());
+  }
+  String substring(int from, int to) const {
+    if (from < 0) from = 0;
+    if ((size_t)from > s.size()) from = (int)s.size();
+    if (to < from) to = from;
+    if ((size_t)to > s.size()) to = (int)s.size();
+    return String(s.substr((size_t)from, (size_t)(to - from)).c_str());
+  }
+
+  String& operator+=(char c) { s += c; return *this; }
+  String& operator+=(const char* o) { s += o; return *this; }
+  String& operator+=(const String& o) { s += o.s; return *this; }
+
+  bool operator==(const String& o) const { return s == o.s; }
+  bool operator==(const char* o) const { return s == std::string(o ? o : ""); }
+  bool operator!=(const String& o) const { return !(*this == o); }
+  bool operator!=(const char* o) const { return !(*this == o); }
+
+  friend String operator+(const String& a, const String& b) {
+    String r; r.s = a.s + b.s; return r;
+  }
+  friend String operator+(const String& a, const char* b) {
+    String r; r.s = a.s + std::string(b ? b : ""); return r;
+  }
+  friend String operator+(const char* a, const String& b) {
+    String r; r.s = std::string(a ? a : "") + b.s; return r;
+  }
+};
+
+// --- Serial stub ------------------------------------------------------------
+struct SerialStub {
+  void begin(long) {}
+  template <class T> void print(const T&) {}
+  template <class T> void print(const T&, int) {}
+  template <class T> void println(const T&) {}
+  template <class T> void println(const T&, int) {}
+  void println() {}
+};
+
+inline SerialStub Serial;
+
+#endif  // NANOESP_NATIVE_ARDUINO_H

--- a/test/native/mocks/NanoESP.h
+++ b/test/native/mocks/NanoESP.h
@@ -1,0 +1,33 @@
+// Minimal NanoESP stub for the PlatformIO `native` test environment.
+// Replaces the real (SoftwareSerial-based) NanoESP class so NanoESP_MQTT.cpp
+// can be compiled on a desktop host. Only the methods that NanoESP_MQTT.cpp
+// references are declared, with inline no-op bodies so the link succeeds. The
+// unit tests exercise topicCompare()/utf8()/charAdd(), none of which touch
+// these methods, so the stub bodies are never run.
+#ifndef NANOESP_NATIVE_NANOESP_H
+#define NANOESP_NATIVE_NANOESP_H
+
+#include "Arduino.h"
+
+// Connection-type macros normally defined in the real NanoESP.h.
+#ifndef TCP
+#define TCP "TCP"
+#endif
+#ifndef UDP
+#define UDP "UDP"
+#endif
+
+class NanoESP {
+ public:
+  NanoESP() {}
+  bool newConnection(int, const String&, const String&, unsigned int) { return false; }
+  int available() { return 0; }
+  bool findUntil(const char*, const char*) { return false; }
+  bool find(const char*) { return false; }
+  long parseInt() { return 0; }
+  int readBytes(char*, int) { return 0; }
+  void println(const String&) {}
+  void write(unsigned char) {}
+};
+
+#endif  // NANOESP_NATIVE_NANOESP_H

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -52,6 +52,14 @@ void test_topic_hash_mismatch_prefix(void) {
   TEST_ASSERT_FALSE(mqtt.topicCompare("a/#", "x/b/c"));
 }
 
+// Regression: a '+' filter must not falsely match a topic with a different
+// number of levels. The second walk index must be seeded from the incoming
+// topic, not from the filter; with the original copy-paste bug the filter
+// "a/+/a" wrongly matched the topic "ab/a".
+void test_topic_plus_level_count_mismatch(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("a/+/a", "ab/a"));
+}
+
 // --------------------------------- utf8 ------------------------------------
 // utf8(input, output): output[0]=0, output[1]=len, output[2..]=payload bytes.
 
@@ -94,6 +102,7 @@ int main(int, char**) {
   RUN_TEST(test_topic_multi_plus_match);
   RUN_TEST(test_topic_hash_match);
   RUN_TEST(test_topic_hash_mismatch_prefix);
+  RUN_TEST(test_topic_plus_level_count_mismatch);
   RUN_TEST(test_utf8_encodes_length_and_payload);
   RUN_TEST(test_utf8_empty_string);
   RUN_TEST(test_charadd_concatenates_in_order);

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -1,0 +1,101 @@
+// Native unit tests for the pure string/byte helpers of NanoESP_MQTT.
+// These run on the desktop host via `pio test -e native`, using the stub
+// Arduino.h / NanoESP.h under test/native/mocks so the real NanoESP_MQTT.cpp
+// compiles without any hardware dependency.
+#include <unity.h>
+
+#include "NanoESP_MQTT.h"
+
+static NanoESP nano;
+static NanoESP_MQTT mqtt(nano);
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ----------------------------- topicCompare --------------------------------
+// topicCompare(filter, topic): filter is the subscription, topic the incoming.
+
+void test_topic_exact_match(void) {
+  TEST_ASSERT_TRUE(mqtt.topicCompare("a/b/c", "a/b/c"));
+}
+
+void test_topic_exact_mismatch(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("a/b/c", "a/b/d"));
+}
+
+void test_topic_empty_filter_is_false(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("", "a/b/c"));
+}
+
+void test_topic_single_plus_match(void) {
+  TEST_ASSERT_TRUE(mqtt.topicCompare("a/+/c", "a/b/c"));
+}
+
+void test_topic_single_plus_mismatch_tail(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("a/+/c", "a/b/d"));
+}
+
+void test_topic_single_plus_mismatch_head(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("a/+/c", "x/b/c"));
+}
+
+void test_topic_multi_plus_match(void) {
+  // '+' may appear in several middle segments; the last segment is literal.
+  TEST_ASSERT_TRUE(mqtt.topicCompare("a/+/c/+/e", "a/b/c/d/e"));
+}
+
+void test_topic_hash_match(void) {
+  TEST_ASSERT_TRUE(mqtt.topicCompare("a/#", "a/b/c"));
+}
+
+void test_topic_hash_mismatch_prefix(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("a/#", "x/b/c"));
+}
+
+// --------------------------------- utf8 ------------------------------------
+// utf8(input, output): output[0]=0, output[1]=len, output[2..]=payload bytes.
+
+void test_utf8_encodes_length_and_payload(void) {
+  unsigned char out[4] = {0xFF, 0xFF, 0xFF, 0xFF};
+  mqtt.utf8("Hi", out);
+  TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+  TEST_ASSERT_EQUAL_UINT8(2, out[1]);
+  TEST_ASSERT_EQUAL_UINT8('H', out[2]);
+  TEST_ASSERT_EQUAL_UINT8('i', out[3]);
+}
+
+void test_utf8_empty_string(void) {
+  unsigned char out[2] = {0xFF, 0xFF};
+  mqtt.utf8("", out);
+  TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+  TEST_ASSERT_EQUAL_UINT8(0, out[1]);
+}
+
+// -------------------------------- charAdd ----------------------------------
+// charAdd(A, lenA, B, lenB, out): concatenates A followed by B into out.
+
+void test_charadd_concatenates_in_order(void) {
+  unsigned char a[3] = {1, 2, 3};
+  unsigned char b[2] = {4, 5};
+  unsigned char out[5] = {0};
+  mqtt.charAdd(a, 3, b, 2, out);
+  const unsigned char expected[5] = {1, 2, 3, 4, 5};
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, out, 5);
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_topic_exact_match);
+  RUN_TEST(test_topic_exact_mismatch);
+  RUN_TEST(test_topic_empty_filter_is_false);
+  RUN_TEST(test_topic_single_plus_match);
+  RUN_TEST(test_topic_single_plus_mismatch_tail);
+  RUN_TEST(test_topic_single_plus_mismatch_head);
+  RUN_TEST(test_topic_multi_plus_match);
+  RUN_TEST(test_topic_hash_match);
+  RUN_TEST(test_topic_hash_mismatch_prefix);
+  RUN_TEST(test_utf8_encodes_length_and_payload);
+  RUN_TEST(test_utf8_empty_string);
+  RUN_TEST(test_charadd_concatenates_in_order);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Phase 1: bugfixes, licence, and CI for the NanoESP library.

- **fix(NanoESP.h):** move include guard above macro block so macros are protected; fix `#define POST "PSOT"` typo → `"POST"` (Closes #4)
- **fix(NanoESP.cpp):** add `default: return false;` to `configWifi()` switch so every code path returns a value
- **fix(NanoESP_HTTP.cpp):** add missing `return` in `sendStreamHeader()` so the result is forwarded to the caller (Closes #4)
- **fix(NanoESP_MQTT.cpp):** replace decimal-literal bitmasks `11110000`/`00000110` with `0b11110000`/`0b00000110` in both `recvMQTT` overloads (Closes #13)
- **refactor(NanoESP_MQTT):** migrate file-scope globals `cleanSession` and `previousMillisMQTTsend` into class members (satisfies the "no global state in .cpp" invariant)
- **chore:** add MIT `LICENSE` (Closes #7), `library.properties` (v1.1.0, Arduino Library Manager), `AGENT_WORKFLOW.md`, and GitHub Actions CI workflow compiling all non-Blynk examples with `arduino-cli` for `arduino:avr:nano`

Closes #4
Closes #7
Closes #13

## Test plan

- [ ] CI `Compile examples (arduino-cli)` job green (all `.ino` sketches except Blynk)
- [ ] CI `Native unit tests (PlatformIO)` job green (`pio test -e native`, 13/13)
- [ ] `#define POST "POST"` confirmed in `NanoESP.h`
- [ ] `0b11110000` confirmed in `NanoESP_MQTT.cpp`
- [ ] No file-scope `cleanSession` or `previousMillisMQTTsend` in `NanoESP_MQTT.cpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)