### PR TITLE
test: PlatformIO native unit tests + CI

### DIFF
--- a/.github/workflows/arduino-compile.yml
+++ b/.github/workflows/arduino-compile.yml
@@ -39,6 +39,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # NOTE: real `pio test -e native` is wired up in Phase 2 (feat/pio-native-tests).
-      - name: Placeholder
-        run: echo "native unit tests are added in Phase 2"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+
+      - name: Run native unit tests
+        run: pio test -e native

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.pio/
+.pioenvs/
+.piolibdeps/
+.vscode/

--- a/AGENT_WORKFLOW.md
+++ b/AGENT_WORKFLOW.md
@@ -27,5 +27,4 @@ Rules for automated/agent contributions to this repository.
 
 ## Testing
 - Examples are compiled in CI with `arduino-cli` for `arduino:avr:nano`.
-- Native unit tests run with `pio test -e native` once the PlatformIO config
-  (`platformio.ini` + `test/`) lands in the Phase 2 test PR.
+- Native unit tests run with `pio test -e native` (see `platformio.ini` and `test/`).

--- a/NanoESP_MQTT.cpp
+++ b/NanoESP_MQTT.cpp
@@ -480,7 +480,7 @@ bool NanoESP_MQTT::topicCompare( const String& topic1, const String& topic2) {
 
   if (topic1.indexOf('+') > 0) {
     int pos1 = topic1.indexOf('/');
-    int pos2 = topic1.indexOf('/');
+    int pos2 = topic2.indexOf('/');
 
     String restTopic1 = topic1;
     String restTopic2 = topic2;

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,11 +10,16 @@ platform = atmelavr
 board = nanoatmega328
 framework = arduino
 monitor_speed = 19200
+; src_dir is the repo root (see [platformio]); restrict the board build to the
+; library sources so it does not pull in examples/ or test/. Building an actual
+; firmware requires supplying your own sketch with setup()/loop().
+build_src_filter = -<*> +<NanoESP.cpp> +<NanoESP_HTTP.cpp> +<NanoESP_MQTT.cpp>
 
 [env:native]
 platform = native
 build_flags =
-    -std=c++17
+    ; gnu++17 (not c++17): NanoESP_MQTT.cpp relies on GNU VLAs.
+    -std=gnu++17
     -I test/native/mocks
     -I .
 ; Compile only the MQTT translation unit against the stub headers; the other

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,23 @@
+; PlatformIO project configuration for the NanoESP library.
+; - env:nano    builds/uploads for the NanoESP board (Arduino Nano, ATmega328).
+; - env:native  runs the host-side Unity unit tests (`pio test -e native`).
+
+[platformio]
+src_dir = .
+
+[env:nano]
+platform = atmelavr
+board = nanoatmega328
+framework = arduino
+monitor_speed = 19200
+
+[env:native]
+platform = native
+build_flags =
+    -std=c++17
+    -I test/native/mocks
+    -I .
+; Compile only the MQTT translation unit against the stub headers; the other
+; library sources need real Arduino/SoftwareSerial and aren't under test here.
+build_src_filter = -<*> +<NanoESP_MQTT.cpp>
+test_build_src = true

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,6 +4,8 @@
 
 [platformio]
 src_dir = .
+; Plain `pio run`/`pio test` target the host tests; env:nano needs a user sketch.
+default_envs = native
 
 [env:nano]
 platform = atmelavr

--- a/test/native/mocks/Arduino.h
+++ b/test/native/mocks/Arduino.h
@@ -1,0 +1,98 @@
+// Minimal Arduino.h stub for the PlatformIO `native` test environment.
+// Provides just enough of the Arduino API (types, String, Serial, millis)
+// for the real NanoESP_MQTT.cpp translation unit to compile and link on a
+// desktop host. None of the hardware-touching stubs are ever executed by the
+// unit tests — they only need to satisfy the compiler and linker.
+#ifndef NANOESP_NATIVE_ARDUINO_H
+#define NANOESP_NATIVE_ARDUINO_H
+
+#include <cstdint>
+#include <string>
+
+typedef uint8_t byte;
+typedef bool boolean;
+
+#define HEX 16
+#define DEC 10
+#define BIN 2
+#define OCT 8
+
+#define F(string_literal) (string_literal)
+#define bitRead(value, bit) (((value) >> (bit)) & 0x01)
+
+inline unsigned long millis() { return 0UL; }
+
+// --- Arduino String shim, backed by std::string -----------------------------
+class String {
+  std::string s;
+ public:
+  String() {}
+  String(const char* c) : s(c ? c : "") {}
+  String(char c) : s(1, c) {}
+  String(int n) : s(std::to_string(n)) {}
+  String(unsigned int n) : s(std::to_string(n)) {}
+  String(long n) : s(std::to_string(n)) {}
+  String(unsigned long n) : s(std::to_string(n)) {}
+
+  unsigned int length() const { return (unsigned int)s.length(); }
+  const char* c_str() const { return s.c_str(); }
+
+  char operator[](int i) const { return s[(size_t)i]; }
+  char& operator[](int i) { return s[(size_t)i]; }
+
+  int indexOf(char c) const {
+    size_t p = s.find(c);
+    return p == std::string::npos ? -1 : (int)p;
+  }
+  int indexOf(const char* o) const {
+    size_t p = s.find(o);
+    return p == std::string::npos ? -1 : (int)p;
+  }
+  int indexOf(const String& o) const { return indexOf(o.c_str()); }
+
+  String substring(int from) const {
+    if (from < 0) from = 0;
+    if ((size_t)from >= s.size()) return String();
+    return String(s.substr((size_t)from).c_str());
+  }
+  String substring(int from, int to) const {
+    if (from < 0) from = 0;
+    if ((size_t)from > s.size()) from = (int)s.size();
+    if (to < from) to = from;
+    if ((size_t)to > s.size()) to = (int)s.size();
+    return String(s.substr((size_t)from, (size_t)(to - from)).c_str());
+  }
+
+  String& operator+=(char c) { s += c; return *this; }
+  String& operator+=(const char* o) { s += o; return *this; }
+  String& operator+=(const String& o) { s += o.s; return *this; }
+
+  bool operator==(const String& o) const { return s == o.s; }
+  bool operator==(const char* o) const { return s == std::string(o ? o : ""); }
+  bool operator!=(const String& o) const { return !(*this == o); }
+  bool operator!=(const char* o) const { return !(*this == o); }
+
+  friend String operator+(const String& a, const String& b) {
+    String r; r.s = a.s + b.s; return r;
+  }
+  friend String operator+(const String& a, const char* b) {
+    String r; r.s = a.s + std::string(b ? b : ""); return r;
+  }
+  friend String operator+(const char* a, const String& b) {
+    String r; r.s = std::string(a ? a : "") + b.s; return r;
+  }
+};
+
+// --- Serial stub ------------------------------------------------------------
+struct SerialStub {
+  void begin(long) {}
+  template <class T> void print(const T&) {}
+  template <class T> void print(const T&, int) {}
+  template <class T> void println(const T&) {}
+  template <class T> void println(const T&, int) {}
+  void println() {}
+};
+
+inline SerialStub Serial;
+
+#endif  // NANOESP_NATIVE_ARDUINO_H

--- a/test/native/mocks/NanoESP.h
+++ b/test/native/mocks/NanoESP.h
@@ -1,0 +1,33 @@
+// Minimal NanoESP stub for the PlatformIO `native` test environment.
+// Replaces the real (SoftwareSerial-based) NanoESP class so NanoESP_MQTT.cpp
+// can be compiled on a desktop host. Only the methods that NanoESP_MQTT.cpp
+// references are declared, with inline no-op bodies so the link succeeds. The
+// unit tests exercise topicCompare()/utf8()/charAdd(), none of which touch
+// these methods, so the stub bodies are never run.
+#ifndef NANOESP_NATIVE_NANOESP_H
+#define NANOESP_NATIVE_NANOESP_H
+
+#include "Arduino.h"
+
+// Connection-type macros normally defined in the real NanoESP.h.
+#ifndef TCP
+#define TCP "TCP"
+#endif
+#ifndef UDP
+#define UDP "UDP"
+#endif
+
+class NanoESP {
+ public:
+  NanoESP() {}
+  bool newConnection(int, const String&, const String&, unsigned int) { return false; }
+  int available() { return 0; }
+  bool findUntil(const char*, const char*) { return false; }
+  bool find(const char*) { return false; }
+  long parseInt() { return 0; }
+  int readBytes(char*, int) { return 0; }
+  void println(const String&) {}
+  void write(unsigned char) {}
+};
+
+#endif  // NANOESP_NATIVE_NANOESP_H

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -52,6 +52,14 @@ void test_topic_hash_mismatch_prefix(void) {
   TEST_ASSERT_FALSE(mqtt.topicCompare("a/#", "x/b/c"));
 }
 
+// Regression: a '+' filter must not falsely match a topic with a different
+// number of levels. The second walk index must be seeded from the incoming
+// topic, not from the filter; with the original copy-paste bug the filter
+// "a/+/a" wrongly matched the topic "ab/a".
+void test_topic_plus_level_count_mismatch(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("a/+/a", "ab/a"));
+}
+
 // --------------------------------- utf8 ------------------------------------
 // utf8(input, output): output[0]=0, output[1]=len, output[2..]=payload bytes.
 
@@ -94,6 +102,7 @@ int main(int, char**) {
   RUN_TEST(test_topic_multi_plus_match);
   RUN_TEST(test_topic_hash_match);
   RUN_TEST(test_topic_hash_mismatch_prefix);
+  RUN_TEST(test_topic_plus_level_count_mismatch);
   RUN_TEST(test_utf8_encodes_length_and_payload);
   RUN_TEST(test_utf8_empty_string);
   RUN_TEST(test_charadd_concatenates_in_order);

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -1,0 +1,101 @@
+// Native unit tests for the pure string/byte helpers of NanoESP_MQTT.
+// These run on the desktop host via `pio test -e native`, using the stub
+// Arduino.h / NanoESP.h under test/native/mocks so the real NanoESP_MQTT.cpp
+// compiles without any hardware dependency.
+#include <unity.h>
+
+#include "NanoESP_MQTT.h"
+
+static NanoESP nano;
+static NanoESP_MQTT mqtt(nano);
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ----------------------------- topicCompare --------------------------------
+// topicCompare(filter, topic): filter is the subscription, topic the incoming.
+
+void test_topic_exact_match(void) {
+  TEST_ASSERT_TRUE(mqtt.topicCompare("a/b/c", "a/b/c"));
+}
+
+void test_topic_exact_mismatch(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("a/b/c", "a/b/d"));
+}
+
+void test_topic_empty_filter_is_false(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("", "a/b/c"));
+}
+
+void test_topic_single_plus_match(void) {
+  TEST_ASSERT_TRUE(mqtt.topicCompare("a/+/c", "a/b/c"));
+}
+
+void test_topic_single_plus_mismatch_tail(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("a/+/c", "a/b/d"));
+}
+
+void test_topic_single_plus_mismatch_head(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("a/+/c", "x/b/c"));
+}
+
+void test_topic_multi_plus_match(void) {
+  // '+' may appear in several middle segments; the last segment is literal.
+  TEST_ASSERT_TRUE(mqtt.topicCompare("a/+/c/+/e", "a/b/c/d/e"));
+}
+
+void test_topic_hash_match(void) {
+  TEST_ASSERT_TRUE(mqtt.topicCompare("a/#", "a/b/c"));
+}
+
+void test_topic_hash_mismatch_prefix(void) {
+  TEST_ASSERT_FALSE(mqtt.topicCompare("a/#", "x/b/c"));
+}
+
+// --------------------------------- utf8 ------------------------------------
+// utf8(input, output): output[0]=0, output[1]=len, output[2..]=payload bytes.
+
+void test_utf8_encodes_length_and_payload(void) {
+  unsigned char out[4] = {0xFF, 0xFF, 0xFF, 0xFF};
+  mqtt.utf8("Hi", out);
+  TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+  TEST_ASSERT_EQUAL_UINT8(2, out[1]);
+  TEST_ASSERT_EQUAL_UINT8('H', out[2]);
+  TEST_ASSERT_EQUAL_UINT8('i', out[3]);
+}
+
+void test_utf8_empty_string(void) {
+  unsigned char out[2] = {0xFF, 0xFF};
+  mqtt.utf8("", out);
+  TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+  TEST_ASSERT_EQUAL_UINT8(0, out[1]);
+}
+
+// -------------------------------- charAdd ----------------------------------
+// charAdd(A, lenA, B, lenB, out): concatenates A followed by B into out.
+
+void test_charadd_concatenates_in_order(void) {
+  unsigned char a[3] = {1, 2, 3};
+  unsigned char b[2] = {4, 5};
+  unsigned char out[5] = {0};
+  mqtt.charAdd(a, 3, b, 2, out);
+  const unsigned char expected[5] = {1, 2, 3, 4, 5};
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, out, 5);
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_topic_exact_match);
+  RUN_TEST(test_topic_exact_mismatch);
+  RUN_TEST(test_topic_empty_filter_is_false);
+  RUN_TEST(test_topic_single_plus_match);
+  RUN_TEST(test_topic_single_plus_mismatch_tail);
+  RUN_TEST(test_topic_single_plus_mismatch_head);
+  RUN_TEST(test_topic_multi_plus_match);
+  RUN_TEST(test_topic_hash_match);
+  RUN_TEST(test_topic_hash_mismatch_prefix);
+  RUN_TEST(test_utf8_encodes_length_and_payload);
+  RUN_TEST(test_utf8_empty_string);
+  RUN_TEST(test_charadd_concatenates_in_order);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Phase 2: PlatformIO native unit-test infrastructure + `topicCompare()` bug fix.

- **test:** add `platformio.ini` with `[env:native]` (host build) and `[env:nano]` (ATmega328 AVR); default env is `native`
- **test:** add stub headers under `test/native/mocks/` (`Arduino.h` with std::string-backed `String` shim, stub `NanoESP.h`) so the real `NanoESP_MQTT.cpp` compiles on a desktop host without any Arduino SDK
- **test:** add 13 Unity tests in `test/test_native/test_main.cpp` covering `topicCompare()` (exact match, mismatch, `+` wildcard, `#` wildcard, level-count guard), `utf8()`, and `charAdd()`
- **fix(NanoESP_MQTT.cpp:topicCompare):** line 483 `int pos2 = topic1.indexOf('/')` → `int pos2 = topic2.indexOf('/')` — the second walk index was seeded from the filter instead of the topic, causing false positives (e.g. filter `a/+/a` wrongly matched topic `ab/a`); regression test `test_topic_plus_level_count_mismatch` covers this
- **ci:** replace CI placeholder job with real `pio test -e native` job; both CI jobs (`compile-examples` + `native-tests`) must be green
- **chore:** add `.gitignore` for `.pio/` build artefacts

## Test plan

- [ ] `pio test -e native` passes locally: 13/13 tests succeeded
- [ ] CI `Native unit tests (PlatformIO)` job green
- [ ] CI `Compile examples (arduino-cli)` job still green
- [ ] Regression test `test_topic_plus_level_count_mismatch` fails when bug is reintroduced (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)